### PR TITLE
update convert_mp4.sh script

### DIFF
--- a/lib/process_cli.js
+++ b/lib/process_cli.js
@@ -216,7 +216,7 @@ const process_cli = function(argv_vals){
 
     if (!argv_vals["--quiet"]) {
       let outputdir = path.dirname(configHLS["--directory-prefix"])
-      let ffmpegcmd = `cd "${configHLS["--directory-prefix"]}" && mkdir "${path.join('..', 'mp4')}" & ffmpeg -allowed_extensions ALL -i "master.m3u8" -c copy -movflags +faststart ${configHLS["--mp4-ffmpeg-options"]} "${path.join('..', 'mp4', `${configMP4["--filename"]}.mp4`)}"`
+      let ffmpegcmd = `cd "${configHLS["--directory-prefix"]}" && mkdir -p "${path.join('..', 'mp4')}" && ffmpeg -protocol_whitelist file,http,https,tcp,tls,crypto -allowed_extensions ALL -i "master.m3u8" -c copy -movflags +faststart ${configHLS["--mp4-ffmpeg-options"]} "${path.join('..', 'mp4', `${configMP4["--filename"]}.mp4`)}"`
 
       switch(argv_vals["--log-level"]) {
         case 1:


### PR DESCRIPTION
`-p` makes command not fail if folder exists
`&&` seems to be required (ubuntu)
additional protocols were required when processing 'Space 1999'